### PR TITLE
Clear Scout context and transaction block context on exit

### DIFF
--- a/lib/action_reporter.rb
+++ b/lib/action_reporter.rb
@@ -37,6 +37,7 @@ module ActionReporter
   @logger = nil
   @error_handler = nil
   @user_id_resolver = nil
+  @no_reporters_warned = false
 
   def enabled_reporters=(reporters)
     @enabled_reporters = reporters || []
@@ -91,6 +92,8 @@ module ActionReporter
   end
 
   def notify(error, context: {})
+    warn_if_no_reporters(:notify)
+
     enabled_reporters.each do |reporter|
       next unless reporter.respond_to?(:notify)
 
@@ -104,6 +107,8 @@ module ActionReporter
 
   def context(args)
     raise ArgumentError, "context must be a Hash" unless args.is_a?(Hash)
+
+    warn_if_no_reporters(:context)
 
     enabled_reporters.each do |reporter|
       next unless reporter.respond_to?(:context)
@@ -254,6 +259,18 @@ module ActionReporter
     ensure
       self.transaction_name = previous_name if name
       self.transaction_id = previous_id if id
+      if context_options.any?
+        context(context_options.transform_values { nil })
+      end
     end
   end
+
+  def warn_if_no_reporters(method_name)
+    return if @no_reporters_warned
+    return unless enabled_reporters.empty?
+
+    @no_reporters_warned = true
+    warn "[action_reporter] #{method_name} called but enabled_reporters is empty"
+  end
+  private :warn_if_no_reporters
 end

--- a/lib/action_reporter/scout_apm_reporter.rb
+++ b/lib/action_reporter/scout_apm_reporter.rb
@@ -13,6 +13,10 @@ module ActionReporter
       scoutapm_context_class.add(new_context)
     end
 
+    def reset_context
+      scoutapm_context_class.clear! if scoutapm_context_class.respond_to?(:clear!)
+    end
+
     def current_remote_addr=(remote_addr)
       scoutapm_context_class.add_user(ip: remote_addr)
     end

--- a/spec/action_reporter/scout_apm_reporter_spec.rb
+++ b/spec/action_reporter/scout_apm_reporter_spec.rb
@@ -42,8 +42,10 @@ RSpec.describe ActionReporter::ScoutApmReporter do
   end
 
   describe "#reset_context" do
-    it "does nothing" do
-      expect { instance.reset_context }.not_to raise_error
+    it "clears ScoutApm context" do
+      allow(ScoutApm::Context).to receive(:clear!)
+      instance.reset_context
+      expect(ScoutApm::Context).to have_received(:clear!)
     end
   end
 

--- a/spec/action_reporter_spec.rb
+++ b/spec/action_reporter_spec.rb
@@ -18,6 +18,16 @@ RSpec.describe ActionReporter do
       expect(enabled_reporters).to eq([])
     end
 
+    it "warns once when notify is called with no reporters", :aggregate_failures do
+      error = StandardError.new("test")
+      expect {
+        described_class.notify(error)
+      }.to output(/enabled_reporters is empty/).to_stderr
+      expect {
+        described_class.notify(error)
+      }.not_to output.to_stderr
+    end
+
     context "when Rails is defined" do
       let(:rails_reporter) { ActionReporter::RailsReporter.new }
 
@@ -798,6 +808,7 @@ RSpec.describe ActionReporter do
       expect(reporter).to have_received(:context).with(hash_including(transaction_name: "Test")).ordered
       expect(reporter).to have_received(:context).with(hash_including(foo: "bar")).ordered
       expect(reporter).to have_received(:context).with(hash_including(transaction_name: nil)).ordered
+      expect(reporter).to have_received(:context).with(hash_including(foo: nil)).ordered
     end
 
     it "does not restore when name/id are not provided", :aggregate_failures do
@@ -811,6 +822,18 @@ RSpec.describe ActionReporter do
 
       expect(described_class.transaction_name).to eq("PreviousName")
       expect(described_class.transaction_id).to eq("previous-id")
+    end
+
+    it "clears additional context after block", :aggregate_failures do
+      reporter = double("Reporter")
+      described_class.enabled_reporters = [reporter]
+      allow(reporter).to receive(:respond_to?).with(:context).and_return(true)
+      allow(reporter).to receive(:context)
+
+      described_class.transaction(foo: "bar") do
+      end
+      expect(reporter).to have_received(:context).with(hash_including(foo: "bar")).ordered
+      expect(reporter).to have_received(:context).with(hash_including(foo: nil)).ordered
     end
 
     it "supports nested transactions", :aggregate_failures do


### PR DESCRIPTION
## Summary
- Call `ScoutApm::Context.clear!` from `ScoutApmReporter#reset_context`.
- Restore `transaction(**context_options)` keys to nil on ensure after the block.
- Warn once when `notify` or `context` runs with an empty `enabled_reporters` list.

## Test plan
- [x] `bundle exec rspec spec/action_reporter_spec.rb spec/action_reporter/scout_apm_reporter_spec.rb` — 75 examples, 0 failures